### PR TITLE
feat: install composer

### DIFF
--- a/php5.6/Dockerfile
+++ b/php5.6/Dockerfile
@@ -18,4 +18,6 @@ RUN docker-php-ext-configure mysqli --with-mysqli=mysqlnd && \
     docker-php-ext-enable memcached mongodb mongo opcache imagick && \
     docker-php-ext-install mysql mysqli pdo_mysql iconv mcrypt exif gd pcntl intl curl xsl xml json zip
 
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+
 CMD ["php-fpm"]

--- a/php7/Dockerfile
+++ b/php7/Dockerfile
@@ -30,4 +30,6 @@ RUN curl -A "Docker" -o /tmp/blackfire-probe.tar.gz -D - -L -s https://blackfire
     tar zxpf /tmp/blackfire-probe.tar.gz -C /tmp && \
     mv /tmp/blackfire-*.so $(php -r "echo ini_get('extension_dir');")/blackfire.so && rm /tmp/blackfire-probe.tar.gz
 
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+
 CMD ["php-fpm"]

--- a/php72/Dockerfile
+++ b/php72/Dockerfile
@@ -30,4 +30,6 @@ RUN curl -A "Docker" -o /tmp/blackfire-probe.tar.gz -D - -L -s https://blackfire
     tar zxpf /tmp/blackfire-probe.tar.gz -C /tmp && \
     mv /tmp/blackfire-*.so $(php -r "echo ini_get('extension_dir');")/blackfire.so && rm /tmp/blackfire-probe.tar.gz
 
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+
 CMD ["php-fpm"]


### PR DESCRIPTION
As composer is heavily used in eZ/SF projects, it would be better to have composer installed instead of relying on the .phar.